### PR TITLE
Add conformer selection for molecules preparation

### DIFF
--- a/tidyscreen/chemspace/chemspace.py
+++ b/tidyscreen/chemspace/chemspace.py
@@ -57,7 +57,7 @@ class ChemSpace:
         
         print("finished")
 
-    def generate_mols_in_table(self,table_name,charge="bcc-ml",pdb=1,mol2=1,pdbqt=1):
+    def generate_mols_in_table(self,table_name,charge="bcc-ml",pdb=1,mol2=1,pdbqt=1,conf_rank=0):
         """
         Will process all SMILES present in a given table an generate molecules stored in different formats
         """
@@ -80,7 +80,7 @@ class ChemSpace:
             print("Computing .pdb files for ligands")
             # Compute and store the .pdb files using pandarallel
             pandarallel.initialize(progress_bar=True) # Activate Progress Bar
-            df.parallel_apply(lambda row: cs_utils.compute_and_store_pdb(row,db,table_name,temp_dir), axis=1)
+            df.parallel_apply(lambda row: cs_utils.compute_and_store_pdb(row,db,table_name,temp_dir,conf_rank), axis=1)
             # Delete all rows in the target table in which .mol2 computation may have failed (errors were registered accondingly)
             general_functions.delete_nulls_table(db,table_name,"pdb_file")
         if mol2 == 1:


### PR DESCRIPTION
When preparing molecules, given that conformers are generated to select the starting structure for molecular docking assays, in some scenarios it may be desired to explicitly set the **percentage** on the set at wich the corresponding conformer will be extracted. 

In this PR, the keyword `conf_rank` has been added to `chemspace.generate_mols_in_table()` in order to specifiy such percentage